### PR TITLE
Fix CNAME validation, README and test..

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DNS Server framework for Deno. Port of [node-named](https://github.com/trevoro/n
 import { DNSServer, CNAMERecord } from "https://deno.land/x/dename/mod.ts";
 
 const server = new DNSServer({
-  subdomain: new CNAMERecord("https://points-to.this"),
+  "domain": new CNAMERecord("points-to.this"),
 });
 
 server.on("listen", () => {

--- a/src/records/cname.ts
+++ b/src/records/cname.ts
@@ -1,4 +1,5 @@
 import { DNSRecordType, IRecord } from "./types.ts";
+import {validateNsName} from "../validators.ts";
 
 export class CNAMERecord implements IRecord {
   type: DNSRecordType = "CNAME";
@@ -7,6 +8,8 @@ export class CNAMERecord implements IRecord {
   constructor(url: string) {
     if (typeof url !== "string")
       throw new Error("Expected qualified URL for CNAME Record");
+    if(!validateNsName(url))
+      throw new Error("Expected valid FQDN for CNAME Record");
     this.target = url;
   }
 }

--- a/src/records/cname.ts
+++ b/src/records/cname.ts
@@ -6,9 +6,7 @@ export class CNAMERecord implements IRecord {
   target: string;
 
   constructor(fqdn: string) {
-    if (typeof fqdn !== "string")
-      throw new Error("Expected qualified URL for CNAME Record");
-    if(!validateNsName(fqdn))
+    if(typeof fqdn !== "string" || !validateNsName(fqdn))
       throw new Error("Expected valid FQDN for CNAME Record");
     this.target = fqdn;
   }

--- a/src/records/cname.ts
+++ b/src/records/cname.ts
@@ -5,11 +5,11 @@ export class CNAMERecord implements IRecord {
   type: DNSRecordType = "CNAME";
   target: string;
 
-  constructor(url: string) {
-    if (typeof url !== "string")
+  constructor(fqdn: string) {
+    if (typeof fqdn !== "string")
       throw new Error("Expected qualified URL for CNAME Record");
-    if(!validateNsName(url))
+    if(!validateNsName(fqdn))
       throw new Error("Expected valid FQDN for CNAME Record");
-    this.target = url;
+    this.target = fqdn;
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -13,7 +13,7 @@ import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 
 const server = new DNSServer({
   txt: new TXTRecord("txt"),
-  cname: new CNAMERecord("https://google.com"),
+  cname: new CNAMERecord("google.com"),
   a: new ARecord("127.0.0.1"),
   aaaa: new AAAARecord("2001:6db8:10b8:20b8:30b8:40b8:3257:9652"),
   mx: new MXRecord({
@@ -85,7 +85,7 @@ Deno.test({
   async fn() {
     const res = await Deno.resolveDns("cname", "CNAME", options);
     assertEquals(res.length, 1);
-    assertEquals(res[0], "https\\:\\/\\/google.com.");
+    assertEquals(res[0], "google.com.");
   },
 });
 


### PR DESCRIPTION
CNAME records are not used for HTTP/HTTPS redirection, but act more like an alias for domains.